### PR TITLE
fixes oauth_token being returned as bytes (#23)

### DIFF
--- a/discogs_client/client.py
+++ b/discogs_client/client.py
@@ -50,7 +50,8 @@ class Client:
             params['oauth_callback'] = callback_url
         postdata = urlencode(params)
 
-        content, status_code = self._fetcher.fetch(self, 'POST', self._request_token_url, data=postdata, headers=params)
+        content, status_code = self._fetcher.fetch(self, 'POST', self._request_token_url, 
+                                                data=postdata, headers=params, json_format=False)
         if status_code != 200:
             raise AuthorizationError('Could not get request token.', status_code, content)
 

--- a/discogs_client/fetchers.py
+++ b/discogs_client/fetchers.py
@@ -78,8 +78,8 @@ class OAuth2Fetcher(Fetcher):
 
     def store_token_from_qs(self, query_string):
         token_dict = dict(parse_qsl(query_string))
-        token = token_dict[b'oauth_token']
-        secret = token_dict[b'oauth_token_secret']
+        token = token_dict[b'oauth_token'].decode('utf-8')
+        secret = token_dict[b'oauth_token_secret'].decode('utf-8')
         self.store_token(token, secret)
         return token, secret
 

--- a/discogs_client/tests/test_fetchers.py
+++ b/discogs_client/tests/test_fetchers.py
@@ -1,3 +1,4 @@
+from discogs_client.fetchers import OAuth2Fetcher
 import unittest
 from discogs_client.tests import DiscogsClientTestCase
 from discogs_client.exceptions import HTTPError
@@ -17,6 +18,29 @@ class FetcherTestCase(DiscogsClientTestCase):
 
         self.assertRaises(HTTPError, lambda: self.m.release(1).title)
         self.assertTrue(self.m._get('/204') is None)
+
+    def test_oauth2_fetcher(self):
+        _fetcher = OAuth2Fetcher(
+            'consumer_key', 'consumer_secret', token=None, secret=None)
+
+        self.assertEqual(_fetcher.client.resource_owner_key, None)
+        self.assertEqual(_fetcher.client.resource_owner_secret, None)
+        
+        query_string = b'oauth_token=token&oauth_token_secret=secret'
+        token, secret = _fetcher.store_token_from_qs(query_string)
+        self.assertEqual(token, 'token')
+        self.assertEqual(secret, 'secret')
+        
+        _fetcher.forget_token()
+        self.assertEqual(_fetcher.client.resource_owner_key, None)
+        self.assertEqual(_fetcher.client.resource_owner_secret, None)
+
+        _fetcher.store_token(token, secret)
+        self.assertEqual(_fetcher.client.resource_owner_key, token)
+        self.assertEqual(_fetcher.client.resource_owner_secret, secret)
+
+        _fetcher.set_verifier('1234567890')
+        self.assertEqual(_fetcher.client.verifier, '1234567890')
 
 
 def suite():


### PR DESCRIPTION
* fixes oauth_token being returned as bytes

* adds tests for OAuth2Fetcher

Co-authored-by: Alistair Hughes <ali.fhughes@gmail.com>